### PR TITLE
Add more RFC5424 Fields

### DIFF
--- a/syslog_rfc5424_formatter.py
+++ b/syslog_rfc5424_formatter.py
@@ -3,6 +3,7 @@ import time
 import socket
 import datetime
 import re
+import os;
 
 version_info = (1, 1, 2)
 __version__ = '.'.join(str(s) for s in version_info)
@@ -72,7 +73,8 @@ class RFC5424Formatter(logging.Formatter, object):
 
     @sd_id.setter
     def sd_id(self, id):
-        if not id: raise Exception("SD-ID cannot be empty")
+        if not id:
+            raise Exception("SD-ID cannot be empty")
         self._sd_id = id
 
     def format(self, record):
@@ -92,7 +94,7 @@ class RFC5424Formatter(logging.Formatter, object):
             isotime = isotime + 'Z'
 
         record.__dict__['isotime'] = isotime
-        record.__dict__['procid'] = self.procid if self.procid else '-'
+        record.__dict__['procid'] = self.procid if self.procid else os.getpid()
         record.__dict__['msgid'] = self.msgid if self.msgid else '-'
 
         if 'structured_data' in record.args:
@@ -109,7 +111,8 @@ class RFC5424Formatter(logging.Formatter, object):
                     default_sdparam[key] = value
 
             if len(default_sdparam) > 0:
-                if self.sd_id in all_sddata: raise Exception("Cannot use same SD-ID twice")
+                if self.sd_id in all_sddata:
+                    raise Exception("Cannot use same SD-ID twice")
                 all_sddata[self.sd_id] = default_sdparam
 
             sd = ''

--- a/syslog_rfc5424_formatter.py
+++ b/syslog_rfc5424_formatter.py
@@ -36,19 +36,6 @@ class RFC5424Formatter(logging.Formatter, object):
     the format string that you pass in the constructor is only
     applied to the message body (and should typically just be %(message)).
 
-    The '- -' sections in the resulting message are the "msg ID" and
-    "Structured-Data" Elements, respectively
-
-    MSGID (Description from RFC5424):
-       The MSGID SHOULD identify the type of message.  For example, a
-   firewall might use the MSGID "TCPIN" for incoming TCP traffic and the
-   MSGID "TCPOUT" for outgoing TCP traffic.  Messages with the same
-   MSGID should reflect events of the same semantics.  The MSGID itself
-   is a string without further semantics.  It is intended for filtering
-   messages on a relay or collector.
-   The NILVALUE SHOULD be used when the syslog application does not, or
-   cannot, provide any value.
-
    Stuctured Data Example:
         [exampleSDID@32473 iut="3" eventSource="Application" eventID="1011"]
     '''

--- a/syslog_rfc5424_formatter.py
+++ b/syslog_rfc5424_formatter.py
@@ -39,7 +39,7 @@ class RFC5424Formatter(logging.Formatter, object):
    Stuctured Data Example:
         [exampleSDID@32473 iut="3" eventSource="Application" eventID="1011"]
     '''
-    def __init__(self, *args, appname='python', procid='-', msgid='-', data='-', **kwargs):
+    def __init__(self, appname='python', procid='-', msgid='-', data='-', *args, **kwargs):
         self._tz_fix = re.compile(r'([+-]\d{2})(\d{2})$')
         self.__defaults ={
             'appname': appname,

--- a/syslog_rfc5424_formatter.py
+++ b/syslog_rfc5424_formatter.py
@@ -39,8 +39,14 @@ class RFC5424Formatter(logging.Formatter, object):
    Stuctured Data Example:
         [exampleSDID@32473 iut="3" eventSource="Application" eventID="1011"]
     '''
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, appname='python', procid='-', msgid='-', data='-', **kwargs):
         self._tz_fix = re.compile(r'([+-]\d{2})(\d{2})$')
+        self.__defaults ={
+            'appname': appname,
+            'procid': procid,
+            'msgid': msgid,
+            'data': data
+            }
         return super(RFC5424Formatter, self).__init__(*args, **kwargs)
 
     def format(self, record):
@@ -60,10 +66,7 @@ class RFC5424Formatter(logging.Formatter, object):
             isotime = isotime + 'Z'
 
         record.__dict__['isotime'] = isotime
-        record.__dict__['appname'] = 'python'
-        record.__dict__['procid'] = '-'
-        record.__dict__['msgid'] = '-'
-        record.__dict__['data'] = '-'
+        record.__dict__.update(self.__defaults)
         record.__dict__.update(record.args)
 
         header = '1 {isotime} {hostname} {appname} {procid} {msgid} {data} '.format(

--- a/syslog_rfc5424_formatter.py
+++ b/syslog_rfc5424_formatter.py
@@ -4,7 +4,7 @@ import socket
 import datetime
 import re
 
-version_info = (1, 1, 1)
+version_info = (1, 1, 2)
 __version__ = '.'.join(str(s) for s in version_info)
 __author__ = 'EasyPost <oss@easypost.com>'
 
@@ -73,8 +73,13 @@ class RFC5424Formatter(logging.Formatter, object):
             isotime = isotime + 'Z'
 
         record.__dict__['isotime'] = isotime
+        record.__dict__['appname'] = 'python'
+        record.__dict__['procid'] = '-'
+        record.__dict__['msgid'] = '-'
+        record.__dict__['data'] = '-'
+        record.__dict__.update(record.args)
 
-        header = '1 {isotime} {hostname} {name} {process} - - '.format(
+        header = '1 {isotime} {hostname} {appname} {procid} {msgid} {data} '.format(
             **record.__dict__
         )
         return header + super(RFC5424Formatter, self).format(record)

--- a/tests/test_syslog_rfc5424_formatter.py
+++ b/tests/test_syslog_rfc5424_formatter.py
@@ -26,14 +26,14 @@ class RFC5424FormatterTestCase(TestCase):
     def test_basic(*args):
         f = RFC5424Formatter()
         r = logging.makeLogRecord({'name': 'root', 'msg': 'A Message'})
-        assert f.format(r) == '1 1970-01-01T00:00:00Z the_host root - - - A Message'
+        assert f.format(r) == '1 1970-01-01T00:00:00Z the_host root 1 - - A Message'
 
     def test_non_utc(*args):
         with mock.patch.dict(os.environ, {'TZ': 'America/Phoenix'}):
             time.tzset()
             f = RFC5424Formatter()
             r = logging.makeLogRecord({'name': 'root', 'msg': 'A Message'})
-            assert f.format(r) == '1 1969-12-31T17:00:00-07:00 the_host root - - - A Message'
+            assert f.format(r) == '1 1969-12-31T17:00:00-07:00 the_host root 1 - - A Message'
 
     def test_properties(*args):
         f = RFC5424Formatter()
@@ -59,7 +59,7 @@ class RFC5424FormatterTestCase(TestCase):
     def test_format_string(*args):
         f = RFC5424Formatter('%(message)s banana')
         r = logging.makeLogRecord({'name': 'root', 'msg': 'A Message'})
-        assert f.format(r) == '1 1970-01-01T00:00:00Z the_host root - - - A Message banana'
+        assert f.format(r) == '1 1970-01-01T00:00:00Z the_host root 1 - - A Message banana'
 
     def test_integration(*args):
         try:
@@ -73,7 +73,7 @@ class RFC5424FormatterTestCase(TestCase):
             h.handle(r)
             s.settimeout(1)
             msg_body = s.recv(1024)
-            assert msg_body == b'<15>1 1970-01-01T00:00:00Z the_host root - - - A Message\x00'
+            assert msg_body == b'<15>1 1970-01-01T00:00:00Z the_host root 1 - - A Message\x00'
             fields = SyslogMessage.parse(msg_body.decode('utf-8'))
             assert fields.severity == SyslogSeverity.debug
             assert fields.facility == SyslogFacility.user
@@ -81,7 +81,7 @@ class RFC5424FormatterTestCase(TestCase):
             assert fields.hostname == 'the_host'
             assert fields.appname == 'root'
             assert fields.msg == 'A Message\x00'
-            assert fields.procid == None
+            assert fields.procid == 1
         finally:
             shutil.rmtree(working_dir)
 
@@ -89,4 +89,4 @@ class RFC5424FormatterTestCase(TestCase):
         with mock.patch('socket.gethostname', side_effect=ValueError):
             f = RFC5424Formatter()
             r = logging.makeLogRecord({'name': 'root', 'msg': 'A Message'})
-            assert f.format(r) == '1 1970-01-01T00:00:00Z - root - - - A Message'
+            assert f.format(r) == '1 1970-01-01T00:00:00Z - root 1 - - A Message'

--- a/tests/test_syslog_rfc5424_formatter.py
+++ b/tests/test_syslog_rfc5424_formatter.py
@@ -44,7 +44,7 @@ class RFC5424FormatterTestCase(TestCase):
     def test_format_string(*args):
         f = RFC5424Formatter('%(message)s banana')
         r = logging.makeLogRecord({'name': 'root', 'msg': 'A Message'})
-        assert f.format(r) == '1 1970-01-01T00:00:00Z the_host root python - - - A Message banana'
+        assert f.format(r) == '1 1970-01-01T00:00:00Z the_host python - - - A Message banana'
 
     def test_integration(*args):
         try:

--- a/tests/test_syslog_rfc5424_formatter.py
+++ b/tests/test_syslog_rfc5424_formatter.py
@@ -42,7 +42,7 @@ class RFC5424FormatterTestCase(TestCase):
             assert f.format(r) == '1 1970-01-01T00:00:00Z the_host python - - - A Message'
 
     def test_format_string(*args):
-        f = RFC5424Formatter('%(message)s banana')
+        f = RFC5424Formatter('python', '-', '-', '-', '%(message)s banana')
         r = logging.makeLogRecord({'name': 'root', 'msg': 'A Message'})
         assert f.format(r) == '1 1970-01-01T00:00:00Z the_host python - - - A Message banana'
 

--- a/tests/test_syslog_rfc5424_formatter.py
+++ b/tests/test_syslog_rfc5424_formatter.py
@@ -26,25 +26,25 @@ class RFC5424FormatterTestCase(TestCase):
     def test_basic(*args):
         f = RFC5424Formatter()
         r = logging.makeLogRecord({'name': 'root', 'msg': 'A Message'})
-        assert f.format(r) == '1 1970-01-01T00:00:00Z the_host python - - - A Message'
+        assert f.format(r) == '1 1970-01-01T00:00:00Z the_host root - - - A Message'
 
     def test_non_utc(*args):
         with mock.patch.dict(os.environ, {'TZ': 'America/Phoenix'}):
             time.tzset()
             f = RFC5424Formatter()
             r = logging.makeLogRecord({'name': 'root', 'msg': 'A Message'})
-            assert f.format(r) == '1 1969-12-31T17:00:00-07:00 the_host python - - - A Message'
+            assert f.format(r) == '1 1969-12-31T17:00:00-07:00 the_host root - - - A Message'
 
     def test_long_pid(*args):
         with mock.patch('os.getpid', return_value=999999):
             f = RFC5424Formatter()
             r = logging.makeLogRecord({'name': 'root', 'msg': 'A Message'})
-            assert f.format(r) == '1 1970-01-01T00:00:00Z the_host python - - - A Message'
+            assert f.format(r) == '1 1970-01-01T00:00:00Z the_host root - - - A Message'
 
     def test_format_string(*args):
-        f = RFC5424Formatter('python', '-', '-', '-', '%(message)s banana')
+        f = RFC5424Formatter('%(message)s banana')
         r = logging.makeLogRecord({'name': 'root', 'msg': 'A Message'})
-        assert f.format(r) == '1 1970-01-01T00:00:00Z the_host python - - - A Message banana'
+        assert f.format(r) == '1 1970-01-01T00:00:00Z the_host root - - - A Message banana'
 
     def test_integration(*args):
         try:
@@ -58,13 +58,13 @@ class RFC5424FormatterTestCase(TestCase):
             h.handle(r)
             s.settimeout(1)
             msg_body = s.recv(1024)
-            assert msg_body == b'<15>1 1970-01-01T00:00:00Z the_host python - - - A Message\x00'
+            assert msg_body == b'<15>1 1970-01-01T00:00:00Z the_host root - - - A Message\x00'
             fields = SyslogMessage.parse(msg_body.decode('utf-8'))
             assert fields.severity == SyslogSeverity.debug
             assert fields.facility == SyslogFacility.user
             assert fields.version == 1
             assert fields.hostname == 'the_host'
-            assert fields.appname == 'python'
+            assert fields.appname == 'root'
             assert fields.msg == 'A Message\x00'
             assert fields.procid == None
         finally:
@@ -74,4 +74,4 @@ class RFC5424FormatterTestCase(TestCase):
         with mock.patch('socket.gethostname', side_effect=ValueError):
             f = RFC5424Formatter()
             r = logging.makeLogRecord({'name': 'root', 'msg': 'A Message'})
-            assert f.format(r) == '1 1970-01-01T00:00:00Z - python - - - A Message'
+            assert f.format(r) == '1 1970-01-01T00:00:00Z - root - - - A Message'

--- a/tests/test_syslog_rfc5424_formatter.py
+++ b/tests/test_syslog_rfc5424_formatter.py
@@ -66,7 +66,7 @@ class RFC5424FormatterTestCase(TestCase):
             assert fields.hostname == 'the_host'
             assert fields.appname == 'python'
             assert fields.msg == 'A Message\x00'
-            assert fields.procid == '-'
+            assert fields.procid == None
         finally:
             shutil.rmtree(working_dir)
 

--- a/tests/test_syslog_rfc5424_formatter.py
+++ b/tests/test_syslog_rfc5424_formatter.py
@@ -35,11 +35,26 @@ class RFC5424FormatterTestCase(TestCase):
             r = logging.makeLogRecord({'name': 'root', 'msg': 'A Message'})
             assert f.format(r) == '1 1969-12-31T17:00:00-07:00 the_host root - - - A Message'
 
-    def test_long_pid(*args):
-        with mock.patch('os.getpid', return_value=999999):
-            f = RFC5424Formatter()
-            r = logging.makeLogRecord({'name': 'root', 'msg': 'A Message'})
-            assert f.format(r) == '1 1970-01-01T00:00:00Z the_host root - - - A Message'
+    def test_properties(*args):
+        f = RFC5424Formatter()
+        f.msgid = 'msgid'
+        f.procid = 999999
+        r = logging.makeLogRecord({'name': 'root', 'msg': 'A Message'})
+        assert f.format(r) == '1 1970-01-01T00:00:00Z the_host root 999999 msgid - A Message'
+
+    def test_properties_override(*args):
+        f = RFC5424Formatter()
+        f.msgid = 'msgid'
+        f.procid = 999999
+        r = logging.makeLogRecord({'name': 'root', 'msg': 'A Message', 'args': {'msgid': 'digsm', 'procid': 1234}})
+        assert f.format(r) == '1 1970-01-01T00:00:00Z the_host root 1234 digsm - A Message'
+
+    def test_structured_data(*args):
+        f = RFC5424Formatter()
+        r = logging.makeLogRecord({'name': 'root', 'msg': 'A Message', 'args': {'structured_data': {'name': 'value', 'sdid@32473': {'escape': '\\"]'}}}})
+        result = f.format(r)
+        assert '[sdid@32473 escape="\\\\\\"\\]"]' in result
+        assert '[Undefined@32473 name="value"]' in result
 
     def test_format_string(*args):
         f = RFC5424Formatter('%(message)s banana')

--- a/tests/test_syslog_rfc5424_formatter.py
+++ b/tests/test_syslog_rfc5424_formatter.py
@@ -26,25 +26,25 @@ class RFC5424FormatterTestCase(TestCase):
     def test_basic(*args):
         f = RFC5424Formatter()
         r = logging.makeLogRecord({'name': 'root', 'msg': 'A Message'})
-        assert f.format(r) == '1 1970-01-01T00:00:00Z the_host root 1 - - A Message'
+        assert f.format(r) == '1 1970-01-01T00:00:00Z the_host python - - - A Message'
 
     def test_non_utc(*args):
         with mock.patch.dict(os.environ, {'TZ': 'America/Phoenix'}):
             time.tzset()
             f = RFC5424Formatter()
             r = logging.makeLogRecord({'name': 'root', 'msg': 'A Message'})
-            assert f.format(r) == '1 1969-12-31T17:00:00-07:00 the_host root 1 - - A Message'
+            assert f.format(r) == '1 1969-12-31T17:00:00-07:00 the_host python - - - A Message'
 
     def test_long_pid(*args):
         with mock.patch('os.getpid', return_value=999999):
             f = RFC5424Formatter()
             r = logging.makeLogRecord({'name': 'root', 'msg': 'A Message'})
-            assert f.format(r) == '1 1970-01-01T00:00:00Z the_host root 999999 - - A Message'
+            assert f.format(r) == '1 1970-01-01T00:00:00Z the_host python - - - A Message'
 
     def test_format_string(*args):
         f = RFC5424Formatter('%(message)s banana')
         r = logging.makeLogRecord({'name': 'root', 'msg': 'A Message'})
-        assert f.format(r) == '1 1970-01-01T00:00:00Z the_host root 1 - - A Message banana'
+        assert f.format(r) == '1 1970-01-01T00:00:00Z the_host root python - - - A Message banana'
 
     def test_integration(*args):
         try:
@@ -58,15 +58,15 @@ class RFC5424FormatterTestCase(TestCase):
             h.handle(r)
             s.settimeout(1)
             msg_body = s.recv(1024)
-            assert msg_body == b'<15>1 1970-01-01T00:00:00Z the_host root 1 - - A Message\x00'
+            assert msg_body == b'<15>1 1970-01-01T00:00:00Z the_host python - - - A Message\x00'
             fields = SyslogMessage.parse(msg_body.decode('utf-8'))
             assert fields.severity == SyslogSeverity.debug
             assert fields.facility == SyslogFacility.user
             assert fields.version == 1
             assert fields.hostname == 'the_host'
-            assert fields.appname == 'root'
+            assert fields.appname == 'python'
             assert fields.msg == 'A Message\x00'
-            assert fields.procid == 1
+            assert fields.procid == '-'
         finally:
             shutil.rmtree(working_dir)
 
@@ -74,4 +74,4 @@ class RFC5424FormatterTestCase(TestCase):
         with mock.patch('socket.gethostname', side_effect=ValueError):
             f = RFC5424Formatter()
             r = logging.makeLogRecord({'name': 'root', 'msg': 'A Message'})
-            assert f.format(r) == '1 1970-01-01T00:00:00Z - root 1 - - A Message'
+            assert f.format(r) == '1 1970-01-01T00:00:00Z - python - - - A Message'


### PR DESCRIPTION
Allow you to set extra fields for app-name, procid, msgid and structured-data. Use by calling
```python
logging.debug('test', {'appname':'python', 'procid':'-', 'msgid':'TestID', 'data':'-'})
```