### PR TITLE
syslog-rfc5424-formatter was broken when constructing records with args

### DIFF
--- a/syslog_rfc5424_formatter.py
+++ b/syslog_rfc5424_formatter.py
@@ -144,7 +144,9 @@ class RFC5424Formatter(logging.Formatter, object):
         else:
             record.__dict__['sd'] = '-'
 
-        record.__dict__.update(record.args)
+        for key in ('procid', 'msgid'):
+            if key in record.args:
+                record.__dict__[key] = record.args.pop(key)
 
         header = '1 {isotime} {hostname} {name} {procid} {msgid} {sd} '.format(
             **record.__dict__


### PR DESCRIPTION
e.g., from `logging.info("%d %d", 1, 2)`

it's still kind of counter-intuitive that `logging.info("%(msgid)d", msgid=1234)` doesn't work. I'm not sure that I entirely love this design of using the record args to pass metadata in.